### PR TITLE
Fix typos in command handlers

### DIFF
--- a/private_captcha_bot/src/main/java/com/telegram_bot/handlers/commands/BanUserCommandHandler.java
+++ b/private_captcha_bot/src/main/java/com/telegram_bot/handlers/commands/BanUserCommandHandler.java
@@ -100,7 +100,7 @@ public class BanUserCommandHandler extends CommandHandler {
         return;
       }
 
-      String message = "User " + user_id + " has beed banned.";
+      String message = "User " + user_id + " has been banned.";
 
       sendMessage(update, telegramClient, chat_id, message, message_id);
     }

--- a/private_captcha_bot/src/main/java/com/telegram_bot/handlers/commands/RestrictUserCommandHandler.java
+++ b/private_captcha_bot/src/main/java/com/telegram_bot/handlers/commands/RestrictUserCommandHandler.java
@@ -188,7 +188,7 @@ public class RestrictUserCommandHandler extends CommandHandler {
         return;
       }
 
-      String message = "The permission of User " + user_id + " has beed changed.";
+      String message = "The permission of User " + user_id + " has been changed.";
 
       sendMessage(update, telegramClient, chat_id, message, message_id);
     }

--- a/private_captcha_bot/src/main/java/com/telegram_bot/handlers/commands/UnBanUserCommandHandler.java
+++ b/private_captcha_bot/src/main/java/com/telegram_bot/handlers/commands/UnBanUserCommandHandler.java
@@ -69,7 +69,7 @@ public class UnBanUserCommandHandler extends CommandHandler {
         return;
       }
 
-      String message = "User " + user_id + " has beed unbanned.";
+      String message = "User " + user_id + " has been unbanned.";
 
       sendMessage(update, telegramClient, chat_id, message, message_id);
     }


### PR DESCRIPTION
## Summary
- correct typo "has beed" -> "has been" in BanUserCommandHandler
- correct typo in UnBanUserCommandHandler
- correct typo in RestrictUserCommandHandler

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68522be60424832d853f2c48cb4be1a5