### PR TITLE
Add usage checks for moderation commands

### DIFF
--- a/private_captcha_bot/src/main/java/com/telegram_bot/handlers/commands/BanUserCommandHandler.java
+++ b/private_captcha_bot/src/main/java/com/telegram_bot/handlers/commands/BanUserCommandHandler.java
@@ -71,6 +71,11 @@ public class BanUserCommandHandler extends CommandHandler {
       showHelpMessage(update, telegramClient, cmd, chat_id, message_id);
 
     } else {
+      Long user_id = extractUserId(update, opts.params, 1);
+      if (user_id == null) {
+        showHelpMessage(update, telegramClient, cmd, chat_id, message_id);
+        return;
+      }
 
       Instant now = Instant.now();
 
@@ -83,7 +88,6 @@ public class BanUserCommandHandler extends CommandHandler {
 
       System.out.println(opts.revoke_messages);
 
-      long user_id = Long.parseLong(opts.params.get(1));
 
       BanChatMember banAction =
           BanChatMember.builder()

--- a/private_captcha_bot/src/main/java/com/telegram_bot/handlers/commands/CommandHandler.java
+++ b/private_captcha_bot/src/main/java/com/telegram_bot/handlers/commands/CommandHandler.java
@@ -3,6 +3,7 @@ package com.telegram_bot.handlers.commands;
 import com.telegram_bot.interfaces.GenericHandler;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.List;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
@@ -50,5 +51,19 @@ public class CommandHandler implements GenericHandler {
     String markdownBlock2 = String.format("```%n%s%n```", usageMessage);
 
     sendMessage(update, telegramClient, chat_id, markdownBlock2, message_id);
+  }
+
+  public Long extractUserId(Update update, List<String> params, int index) {
+    if (params != null && params.size() > index) {
+      try {
+        return Long.parseLong(params.get(index));
+      } catch (NumberFormatException e) {
+        return null;
+      }
+    }
+    if (update.getMessage().getReplyToMessage() != null) {
+      return update.getMessage().getReplyToMessage().getFrom().getId();
+    }
+    return null;
   }
 }

--- a/private_captcha_bot/src/main/java/com/telegram_bot/handlers/commands/RestrictUserCommandHandler.java
+++ b/private_captcha_bot/src/main/java/com/telegram_bot/handlers/commands/RestrictUserCommandHandler.java
@@ -134,10 +134,13 @@ public class RestrictUserCommandHandler extends CommandHandler {
       showHelpMessage(update, telegramClient, cmd, chat_id, message_id);
 
     } else {
+      Long user_id = extractUserId(update, opts.params, 1);
+      if (user_id == null) {
+        showHelpMessage(update, telegramClient, cmd, chat_id, message_id);
+        return;
+      }
 
       System.out.println(opts.can_send_messages);
-
-      long user_id = Long.parseLong(opts.params.get(1));
 
       if (opts.allow_all) {
         opts.can_send_messages = true;

--- a/private_captcha_bot/src/main/java/com/telegram_bot/handlers/commands/UnBanUserCommandHandler.java
+++ b/private_captcha_bot/src/main/java/com/telegram_bot/handlers/commands/UnBanUserCommandHandler.java
@@ -57,8 +57,11 @@ public class UnBanUserCommandHandler extends CommandHandler {
       showHelpMessage(update, telegramClient, cmd, chat_id, message_id);
 
     } else {
-
-      long user_id = Long.parseLong(opts.params.get(1));
+      Long user_id = extractUserId(update, opts.params, 1);
+      if (user_id == null) {
+        showHelpMessage(update, telegramClient, cmd, chat_id, message_id);
+        return;
+      }
 
       UnbanChatMember banAction = UnbanChatMember.builder().chatId(chat_id).userId(user_id).build();
 


### PR DESCRIPTION
## Summary
- ensure BanUserCommandHandler, UnBanUserCommandHandler and RestrictUserCommandHandler validate arguments before use
- allow banning, unbanning and restricting by replying to a user's message
- move repeated user ID parsing logic into CommandHandler.extractUserId()

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685247a207d4832da7314c4ddff9b16b