### PR TITLE
Fix invite users option description

### DIFF
--- a/private_captcha_bot/src/main/java/com/telegram_bot/handlers/commands/RestrictUserCommandHandler.java
+++ b/private_captcha_bot/src/main/java/com/telegram_bot/handlers/commands/RestrictUserCommandHandler.java
@@ -83,7 +83,7 @@ class RestrictUserCommandOptions {
   @Option(
       names = {"--invite"},
       defaultValue = "false",
-      description = "Can sinvite users.")
+      description = "Can invite users.")
   boolean can_invite_users;
 
   @Option(


### PR DESCRIPTION
## Summary
- fix typo in `--invite` option description in `RestrictUserCommandHandler`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854dd97ff6c832d9ca5206722075405