### PR TITLE
Add reflection test for command handlers

### DIFF
--- a/private_captcha_bot/src/test/java/com/telegram_bot/AppTest.java
+++ b/private_captcha_bot/src/test/java/com/telegram_bot/AppTest.java
@@ -1,6 +1,12 @@
-package com.david;
+package com.telegram_bot;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+
+import com.telegram_bot.PrivateCatchaBot;
+import com.telegram_bot.handlers.commands.CommandHandler;
+import java.lang.reflect.Field;
+import java.util.Map;
 
 import org.junit.Test;
 
@@ -10,5 +16,17 @@ public class AppTest {
   @Test
   public void shouldAnswerWithTrue() {
     assertTrue(true);
+  }
+
+  @Test
+  public void shouldContainBanCommandHandler() throws Exception {
+    PrivateCatchaBot bot = new PrivateCatchaBot("dummy");
+    Field field = PrivateCatchaBot.class.getDeclaredField("commandHandlerMap");
+    field.setAccessible(true);
+
+    @SuppressWarnings("unchecked")
+    Map<String, CommandHandler> map = (Map<String, CommandHandler>) field.get(bot);
+
+    assertNotNull("/ban handler should be registered", map.get("/ban"));
   }
 }


### PR DESCRIPTION
## Summary
- rename `AppTest` package to `com.telegram_bot`
- add a JUnit4 test verifying `/ban` command handler is registered

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68550428d35c832dafb33aff1b8a5d19