### PR TITLE
Add modular verification handlers

### DIFF
--- a/private_captcha_bot/src/main/java/com/telegram_bot/PrivateCatchaBot.java
+++ b/private_captcha_bot/src/main/java/com/telegram_bot/PrivateCatchaBot.java
@@ -1,24 +1,19 @@
 package com.telegram_bot;
 
-import static java.lang.Math.toIntExact;
-
+import com.telegram_bot.handlers.callbacks.CaptchaPassCallbackHandler;
 import com.telegram_bot.handlers.commands.BanUserCommandHandler;
 import com.telegram_bot.handlers.commands.CommandHandler;
 import com.telegram_bot.handlers.commands.RestrictUserCommandHandler;
 import com.telegram_bot.handlers.commands.UnBanUserCommandHandler;
+import com.telegram_bot.handlers.events.DefaultNewMemberVerificationHandler;
+import com.telegram_bot.interfaces.callbacks.CallbackQueryHandler;
+import com.telegram_bot.interfaces.events.NewMemberVerificationHandler;
 import java.util.HashMap;
 import java.util.Map;
 import org.telegram.telegrambots.client.okhttp.OkHttpTelegramClient;
 import org.telegram.telegrambots.longpolling.util.LongPollingSingleThreadUpdateConsumer;
-import org.telegram.telegrambots.meta.api.methods.groupadministration.RestrictChatMember;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
-import org.telegram.telegrambots.meta.api.methods.updatingmessages.EditMessageText;
-import org.telegram.telegrambots.meta.api.objects.ChatPermissions;
 import org.telegram.telegrambots.meta.api.objects.Update;
-import org.telegram.telegrambots.meta.api.objects.User;
-import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
-import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton;
-import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardRow;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 import org.telegram.telegrambots.meta.generics.TelegramClient;
 
@@ -26,6 +21,8 @@ public class PrivateCatchaBot implements LongPollingSingleThreadUpdateConsumer {
   private final TelegramClient telegramClient;
 
   private final Map<String, CommandHandler> commandHandlerMap = new HashMap<>();
+  private final Map<String, CallbackQueryHandler> callbackQueryHandlerMap = new HashMap<>();
+  private final NewMemberVerificationHandler newMemberHandler = new DefaultNewMemberVerificationHandler();
 
   public PrivateCatchaBot(String botToken) {
     telegramClient = new OkHttpTelegramClient(botToken);
@@ -33,54 +30,16 @@ public class PrivateCatchaBot implements LongPollingSingleThreadUpdateConsumer {
     commandHandlerMap.put("/ban", new BanUserCommandHandler());
     commandHandlerMap.put("/unban", new UnBanUserCommandHandler());
     commandHandlerMap.put("/restrict", new RestrictUserCommandHandler());
+
+    callbackQueryHandlerMap.put("Catcha_pass", new CaptchaPassCallbackHandler());
   }
 
   @Override
   public void consume(Update update) {
 
     if (update.hasMessage() && !update.getMessage().getNewChatMembers().isEmpty()) {
-      User user = update.getMessage().getNewChatMembers().get(0);
-
-      String userName = user.getUserName();
-      String firstName = user.getFirstName();
-      String lastName = user.getLastName();
-
-      long chat_id = update.getMessage().getChatId();
-      long user_id = user.getId();
-
-      SendMessage message =
-          SendMessage // Create a message object
-              .builder()
-              .chatId(chat_id)
-              .text("Hello " + firstName + " " + lastName + " (" + userName + "). Are you a human?")
-              .replyMarkup(
-                  InlineKeyboardMarkup.builder()
-                      .keyboardRow(
-                          new InlineKeyboardRow(
-                              InlineKeyboardButton.builder()
-                                  .text("Click to confirm")
-                                  .callbackData("Catcha_pass")
-                                  .build()))
-                      .build())
-              .build();
-
-      ChatPermissions permission = ChatPermissions.builder().canSendMessages(false).build();
-
-      RestrictChatMember restriction =
-          RestrictChatMember.builder()
-              .chatId(chat_id)
-              .userId(user_id)
-              .permissions(permission)
-              .build();
-
       try {
-        telegramClient.execute(message); // Sending our message object to user
-      } catch (TelegramApiException e) {
-        e.printStackTrace();
-      }
-
-      try {
-        telegramClient.execute(restriction); // Sending our message object to user
+        newMemberHandler.handle(update, telegramClient);
       } catch (TelegramApiException e) {
         e.printStackTrace();
       }
@@ -113,43 +72,11 @@ public class PrivateCatchaBot implements LongPollingSingleThreadUpdateConsumer {
 
     } else if (update.hasCallbackQuery()) {
 
-      String call_data = update.getCallbackQuery().getData();
-
-      long message_id = update.getCallbackQuery().getMessage().getMessageId();
-      long chat_id = update.getCallbackQuery().getMessage().getChatId();
-
-      User from = update.getCallbackQuery().getFrom();
-
-      long user_id = from.getId();
-
-      if (call_data.equals("Catcha_pass")) {
-
-        String answer = "Thanks for your cooperation.";
-
-        EditMessageText new_message =
-            EditMessageText.builder()
-                .chatId(chat_id)
-                .messageId(toIntExact(message_id))
-                .text(answer)
-                .build();
-
+      String data = update.getCallbackQuery().getData();
+      CallbackQueryHandler handler = callbackQueryHandlerMap.get(data);
+      if (handler != null) {
         try {
-          telegramClient.execute(new_message);
-        } catch (TelegramApiException e) {
-          e.printStackTrace();
-        }
-
-        ChatPermissions permission = ChatPermissions.builder().canSendMessages(true).build();
-
-        RestrictChatMember release =
-            RestrictChatMember.builder()
-                .chatId(chat_id)
-                .userId(user_id)
-                .permissions(permission)
-                .build();
-
-        try {
-          telegramClient.execute(release);
+          handler.handle(update, telegramClient);
         } catch (TelegramApiException e) {
           e.printStackTrace();
         }

--- a/private_captcha_bot/src/main/java/com/telegram_bot/handlers/callbacks/CaptchaPassCallbackHandler.java
+++ b/private_captcha_bot/src/main/java/com/telegram_bot/handlers/callbacks/CaptchaPassCallbackHandler.java
@@ -1,0 +1,50 @@
+package com.telegram_bot.handlers.callbacks;
+
+import static java.lang.Math.toIntExact;
+
+import com.telegram_bot.interfaces.callbacks.CallbackQueryHandler;
+import org.telegram.telegrambots.meta.api.methods.groupadministration.RestrictChatMember;
+import org.telegram.telegrambots.meta.api.methods.updatingmessages.EditMessageText;
+import org.telegram.telegrambots.meta.api.objects.ChatPermissions;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.api.objects.User;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
+
+/** Handles the "Catcha_pass" callback query to verify a user. */
+public class CaptchaPassCallbackHandler implements CallbackQueryHandler {
+
+    @Override
+    public void handle(Update update, TelegramClient telegramClient) throws TelegramApiException {
+        if (!update.hasCallbackQuery()) {
+            return;
+        }
+
+        String data = update.getCallbackQuery().getData();
+        if (!"Catcha_pass".equals(data)) {
+            return;
+        }
+
+        long messageId = update.getCallbackQuery().getMessage().getMessageId();
+        long chatId = update.getCallbackQuery().getMessage().getChatId();
+        User from = update.getCallbackQuery().getFrom();
+        long userId = from.getId();
+
+        EditMessageText newMessage =
+                EditMessageText.builder()
+                        .chatId(chatId)
+                        .messageId(toIntExact(messageId))
+                        .text("Thanks for your cooperation.")
+                        .build();
+        telegramClient.execute(newMessage);
+
+        ChatPermissions permission = ChatPermissions.builder().canSendMessages(true).build();
+        RestrictChatMember release =
+                RestrictChatMember.builder()
+                        .chatId(chatId)
+                        .userId(userId)
+                        .permissions(permission)
+                        .build();
+        telegramClient.execute(release);
+    }
+}

--- a/private_captcha_bot/src/main/java/com/telegram_bot/handlers/events/DefaultNewMemberVerificationHandler.java
+++ b/private_captcha_bot/src/main/java/com/telegram_bot/handlers/events/DefaultNewMemberVerificationHandler.java
@@ -1,0 +1,58 @@
+package com.telegram_bot.handlers.events;
+
+import com.telegram_bot.interfaces.events.NewMemberVerificationHandler;
+import org.telegram.telegrambots.meta.api.methods.groupadministration.RestrictChatMember;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.ChatPermissions;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.api.objects.User;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton;
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardRow;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
+
+/** Default implementation that greets new users and restricts them until verification. */
+public class DefaultNewMemberVerificationHandler implements NewMemberVerificationHandler {
+
+    @Override
+    public void handle(Update update, TelegramClient telegramClient) throws TelegramApiException {
+        if (!update.hasMessage() || update.getMessage().getNewChatMembers().isEmpty()) {
+            return;
+        }
+
+        User user = update.getMessage().getNewChatMembers().get(0);
+        String userName = user.getUserName();
+        String firstName = user.getFirstName();
+        String lastName = user.getLastName();
+
+        long chatId = update.getMessage().getChatId();
+        long userId = user.getId();
+
+        SendMessage message =
+                SendMessage.builder()
+                        .chatId(chatId)
+                        .text("Hello " + firstName + " " + lastName + " (" + userName + "). Are you a human?")
+                        .replyMarkup(
+                                InlineKeyboardMarkup.builder()
+                                        .keyboardRow(
+                                                new InlineKeyboardRow(
+                                                        InlineKeyboardButton.builder()
+                                                                .text("Click to confirm")
+                                                                .callbackData("Catcha_pass")
+                                                                .build()))
+                                        .build())
+                        .build();
+
+        ChatPermissions permission = ChatPermissions.builder().canSendMessages(false).build();
+        RestrictChatMember restriction =
+                RestrictChatMember.builder()
+                        .chatId(chatId)
+                        .userId(userId)
+                        .permissions(permission)
+                        .build();
+
+        telegramClient.execute(message);
+        telegramClient.execute(restriction);
+    }
+}

--- a/private_captcha_bot/src/main/java/com/telegram_bot/interfaces/callbacks/CallbackQueryHandler.java
+++ b/private_captcha_bot/src/main/java/com/telegram_bot/interfaces/callbacks/CallbackQueryHandler.java
@@ -1,0 +1,10 @@
+package com.telegram_bot.interfaces.callbacks;
+
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
+
+/** Generic interface for processing callback queries. */
+public interface CallbackQueryHandler {
+    void handle(Update update, TelegramClient telegramClient) throws TelegramApiException;
+}

--- a/private_captcha_bot/src/main/java/com/telegram_bot/interfaces/events/NewMemberVerificationHandler.java
+++ b/private_captcha_bot/src/main/java/com/telegram_bot/interfaces/events/NewMemberVerificationHandler.java
@@ -1,0 +1,10 @@
+package com.telegram_bot.interfaces.events;
+
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
+
+/** Interface for handling new member join events that require verification. */
+public interface NewMemberVerificationHandler {
+    void handle(Update update, TelegramClient telegramClient) throws TelegramApiException;
+}


### PR DESCRIPTION
## Summary
- add new interfaces for new-member verification and callback queries
- implement default handlers for welcoming and verifying users
- refactor `PrivateCatchaBot` to use new handler objects

## Testing
- `mvn -q -f private_captcha_bot/pom.xml test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68522877175c832db34e826640c3dfa8