### PR TITLE
Add Dockerfile for building the Java bot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM maven:3.9.6-eclipse-temurin-17 AS build
+WORKDIR /build
+COPY private_captcha_bot/pom.xml private_captcha_bot/pom.xml
+RUN mvn -f private_captcha_bot/pom.xml dependency:go-offline
+COPY private_captcha_bot/src private_captcha_bot/src
+RUN mvn -f private_captcha_bot/pom.xml package -DskipTests
+
+FROM eclipse-temurin:17-jre-jammy AS runtime
+WORKDIR /app
+COPY --from=build /build/private_captcha_bot/target/private_captcha_bot-*.jar ./app.jar
+COPY --from=build /build/private_captcha_bot/target/lib ./lib
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+if [ -z "$API_KEY" ]; then
+  echo "Error: API_KEY environment variable is not set" >&2
+  exit 1
+fi
+
+exec java -jar /app/app.jar


### PR DESCRIPTION
## Summary
- provide a Dockerfile to build and run the bot
- add an entrypoint script that validates `API_KEY`

## Testing
- `mvn -q -f private_captcha_bot/pom.xml test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855093d0e8c832d8bdc9bf93b9a04e9